### PR TITLE
会話ダイアログが大量に出て進行できない

### DIFF
--- a/src/class/Area.js
+++ b/src/class/Area.js
@@ -1,3 +1,4 @@
+const FRAMES_FOR_NEW_ENTER = 4
 export default class Area extends Phaser.GameObjects.Zone {
   constructor (scene, zoneX, zoneY, zoneWidth, zoneHeight) {
     super(scene, zoneX, zoneY, zoneWidth, zoneHeight)
@@ -5,7 +6,7 @@ export default class Area extends Phaser.GameObjects.Zone {
     this.lastEnteredFrame = 0
     scene.physics.world.enable(this)
     scene.physics.add.overlap(this, scene.player, () => {
-      const newEntered = this.lastEnteredFrame < (scene.frame - 2)
+      const newEntered = this.lastEnteredFrame < (scene.frame - FRAMES_FOR_NEW_ENTER)
       this.lastEnteredFrame = scene.frame
       if (!newEntered) return
       if (this.event && this.active) {


### PR DESCRIPTION
https://github.com/laineus/unsung-kingdom/issues/2

# 問題
プレイヤーのブラウザの処理速度次第では、
エリアへの侵入イベントが何度も発火してしまう

# 対応内容
新しくエリアへ侵入したと判定されるフレーム差の数を広げる

# そもそもなぜこんな実装になっているのか…

```
const newEntered = this.lastEnteredFrame < (scene.frame - 2)
```

Phaser3のZoneクラスには物体と接触しているときのイベントがあるが、接触を「開始したとき」や「終了したとき」のイベントがない。
接触中は毎フレームイベントが発火するが、この発火はメインスレッドのループと同期されていないようで、実行順や回数が一致しない。
そのせいでメインスレッドを通してフラグ管理を自作することも難しい。

なので、 `実行順や回数が一致しない` の度合いを見越して「2フレーム以上overlapが発火されていなければ一度エリアを出た」と見なしていた。

根本的な解決ではないが、とりあえず4に増やした。