### PR TITLE
Split long text in speech bubble with keeping array length

### DIFF
--- a/src/class/Talk.js
+++ b/src/class/Talk.js
@@ -8,6 +8,16 @@ export default class Talk extends Phaser.GameObjects.Container {
     this.events = events
     this.callback = callback
     this.index = 0
+    this.events = events.reduce((arr, v) => {
+      if (v && typeof v.text === 'string') {
+        v.text.split('|').forEach(text => {
+          arr.push(Object.assign({}, v, { text }))
+        })
+      } else {
+        arr.push(Object.assign({}, v))
+      }
+      return arr
+    }, [])
     scene.add.existing(this)
     this.npc = this.events.filter(v => v && v.chara.constructor === Character).map(v => v.chara)
     this.npc.forEach(c => {

--- a/src/locales/en/index.js
+++ b/src/locales/en/index.js
@@ -273,9 +273,10 @@ export default {
   templeCharacters,
   storyTelling: [
     "The king is dead.\nThe gates of the castle are barred, the glory beyond unseen for generations.\nFollowing the death of the Great King, the Kingdom abruptly fell.",
+    "— The history of Bellion",
     "After a thousand years the kingdom was forgotten to the world, it's name long lost.\nBut the descendants of Verion never left the land where King Edgar sleeps peacefully.",
     "At some point, magicians who lamented the death of the good king discovered a way to alter time.",
-    "It was unnatural to defy the laws of nature, but for the good king they were willing to rewrite history.",
+    "It was unnatural to defy the laws of nature,\nbut for the good king they were willing to rewrite history.",
   ],
   missionDescription: {
     m0_1: {

--- a/src/locales/en/room.js
+++ b/src/locales/en/room.js
@@ -59,7 +59,7 @@ export const roomEv = [
       // 0.4.x
       "The descendants of Verion have always regretted his death.", // ann
       "It's true.", // jaquelyn
-      "According to the history of the Kingdom of Verion, the king will be assassinated tomorrow evening in the royal gardens. ", // francisca
+      "According to the history of the Kingdom of Verion,|the king will be assassinated tomorrow evening in the royal gardens.", // francisca
       "The identity and purpose of the assassin is unknown.", // francisca
       "A mysterious figure only known by the title history gave him: Jack the Kingkiller", // ann
       "Indeed.", // francisca


### PR DESCRIPTION
**Before:**

![ScreenShot_20210227_112515_1](https://user-images.githubusercontent.com/30072663/109372957-9a873080-78ef-11eb-97d7-a97244349503.png)

**After:**

Just you need is adding `|`.

```diff
- "According to the history of the Kingdom of Verion, the king will be assassinated tomorrow evening in the royal gardens."
+ "According to the history of the Kingdom of Verion,|the king will be assassinated tomorrow evening in the royal gardens."
```

![ScreenShot_20210227_112515_2](https://user-images.githubusercontent.com/30072663/109372959-9e1ab780-78ef-11eb-92d3-c20d5eb01970.png)
![ScreenShot_20210227_112515_3](https://user-images.githubusercontent.com/30072663/109372961-a07d1180-78ef-11eb-99ce-fa6bea5e9514.png)
